### PR TITLE
Only perform shallow checkout for statistics

### DIFF
--- a/test-stats
+++ b/test-stats
@@ -60,7 +60,7 @@ def clone(url, directory):
     while os.path.exists(target):
         target += ".x"
     try:
-        subprocess.check_call(["git", "clone", url, target], cwd=directory, stdout=sys.stderr.fileno())
+        subprocess.check_call(["git", "clone", "--depth", "1", url, target], cwd=directory, stdout=sys.stderr.fileno())
     except subprocess.CalledProcessError:
         return None
     return target


### PR DESCRIPTION
We only need to look at the current files and directories.
By using "--depth 1", we avoid pulling the entire git history.